### PR TITLE
Add ActivityError interface

### DIFF
--- a/core/activity/error.go
+++ b/core/activity/error.go
@@ -8,6 +8,13 @@ type Error struct {
 	errorData    interface{}
 }
 
+type ActivityError interface {
+	Error() string
+	ActivityName() string
+	Data() interface{}
+	Code() string
+}
+
 func NewError(errorText string, code string, errorData interface{}) *Error {
 	return &Error{errorStr: errorText, errorData: errorData, errorCode: code}
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: N/A

**What is the current behavior?**
In TaskEvent and FlowEvent, the TaskError() and FlowError() methods return an object with interface error but it can also be an object of type activity.Error. However there is no interface to expose methods of this type.

**What is the new behavior?**
An interface has been added.

An example of use-case can be:
```
func handleErrorInSpan(span opentracing.Span, err error) {
	span.SetTag("error", true)
	span.SetTag("message", err.(error).Error())

	switch err.(type) {
	case act.ActivityError:
		span.SetTag("error.object", err.(act.ActivityError).Data())
	}
}
```