### PR TITLE
Default value for ENV_APP_PROPERTY_RESOLVER_KEY

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ func GetAppPropertiesValueResolver() string {
 	if len(key) > 0 {
 		return key
 	}
-	return ""
+	return "env"
 }
 
 func PublishAuditEvents() bool {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently when setting ```FLOGO_APP_PROPS_OVERRIDE``` environment variable to override properties (in a JSON file or as a comma-separated list of key=value), it is mandatory to set ```FLOGO_APP_PROPS_VALUE_RESOLVER```. The value of this latter variable must match a registered ```app.PropertyValueResolver```. The only registered PropertyValueResolver available in flogo-lib is ```env```.

**What is the new behavior?**
Since it is very likely that the ```env``` PropertyValueResolver will be used, it is now set as the default value.
It is no longer mandatory to set the ```FLOGO_APP_PROPS_VALUE_RESOLVER``` environment variable.
